### PR TITLE
Option to set AWS credentials via Web form

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ Using the new IAM Users from AWS you can provide more specific and secure access
     //Check this parameter in http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getSignedUrl-property
     var AWS_SignedUrl_Expires = 900; //This is the default value for expires getSignedUrl (value in seconds, 15 mins set)
     var TITLE = 'S3 Bucket browser';
-	
+
+	**Notes:** You can leave the `AccessKeyId` and `SecretAccessKey` as empty strings to avoid exposing AWS credentials publicly. 
+	In this case the S3 Bucket Browser will prompt user for credentials via WEB form.
+
 3) Navigate to index.html and start browsing...
+
+
 
 ## Copyright and License
 

--- a/css/theme.css
+++ b/css/theme.css
@@ -183,7 +183,7 @@ div.breadcrumb a:hover {
 	margin: auto;
 	left: 50%;
 	margin-top: 10%;
-	margin-left: -200px;
+	margin-left: -250px;
 	padding: 100px 100px;
 	background-color: white;
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -175,3 +175,23 @@ div.breadcrumb a:hover {
 	opacity: 0.2; /* also -moz-opacity, etc. */
 	z-index: 10;
 }
+
+#loginForm {
+	position: absolute;
+	width: 300px;
+	border: 1px solid silver;
+	margin: auto;
+	left: 50%;
+	margin-top: 10%;
+	margin-left: -200px;
+	padding: 100px 100px;
+	background-color: white;
+}
+
+#loginForm label {
+	display: block;
+}
+
+#loginForm input[type=password] {
+	width: 300px;
+}

--- a/index.html
+++ b/index.html
@@ -28,4 +28,4 @@
 			</div>
 		</div>
 	</body>
-</html>  
+</html>

--- a/js/config.js
+++ b/js/config.js
@@ -1,5 +1,5 @@
-var AWS_AccessKeyId = '';
-var AWS_SecretAccessKey = '';
+var AWS_AccessKeyId = '';  // leave this empty for WEB form auth
+var AWS_SecretAccessKey = '';  // leave this empty for WEB form auth
 var AWS_Region = 'us-east-1';
 var AWS_BucketName = '';
 var AWS_MaxKeys = 500; //How many objects will retrive (include folders and items)

--- a/js/s3bb.js
+++ b/js/s3bb.js
@@ -143,7 +143,7 @@ function login() {
 	var SecretAccessKey = $('input[name=SecretAccessKey]').val();
 
 	if (AccessKeyId === "" || SecretAccessKey === "") {
-		alert('AccessKeyId and SecretAccessKey are required');
+		return alert('AccessKeyId and SecretAccessKey are required');
 	}
 
 	// update config data

--- a/js/s3bb.js
+++ b/js/s3bb.js
@@ -1,6 +1,4 @@
-AWS.config.update({accessKeyId: AWS_AccessKeyId, secretAccessKey: AWS_SecretAccessKey});
-AWS.config.region = AWS_Region;
-var bucket = new AWS.S3({params: {Bucket: AWS_BucketName}});
+var bucket = null;
 
 function listMoreObjects(marker, prefix, countFiles, countFolders) {
 	$('#overlay').show();
@@ -22,7 +20,7 @@ function listObjects(prefix) {
 	$('#overlay').show();
 	$('#status').html('<div id="statusimg"></div>Loading...');
 	$('#objects').empty();
-	
+
 	bucket.listObjects({MaxKeys: AWS_MaxKeys, Prefix : prefix, Delimiter : '/' },function (err, data) {
 		if (err) {
 			$('#status').html('<img src="img/exclamation-red.png"> Could not load objects from S3');
@@ -120,7 +118,51 @@ function init() {
 	$('#headertitle').html(TITLE);
 }
 
-$( document ).ready(function() {
-	init();
+function runS3Browser() {
+	AWS.config.region = AWS_Region;
+	AWS.config.update({accessKeyId: AWS_AccessKeyId, secretAccessKey: AWS_SecretAccessKey});
+	bucket = new AWS.S3({params: {Bucket: AWS_BucketName}});
 	listObjects(AWS_Prefix);
+}
+
+function showLoginForm() {
+	$('#overlay').hide();
+	$("body").append(
+		'<div id="loginForm">' +
+		'<h2>AWS Credentials</h2><br />' +
+		'<label for="AccessKeyId">AccessKeyId:</label> <input id="AccessKeyId" type="password" name="AccessKeyId" maxlength="21"><br />' +
+		'<label for="SecretAccessKey">SecretAccessKey:</label> <input id="SecretAccessKey" type="password" name="SecretAccessKey" maxlength="41"><br /><br />' +
+		'<input type="button" value="      Login      " onclick="login()">' +
+		'</div>'
+	);
+}
+
+function login() {
+	// validation
+	var AccessKeyId = $('input[name=AccessKeyId]').val();
+	var SecretAccessKey = $('input[name=SecretAccessKey]').val();
+
+	if (AccessKeyId === "" || SecretAccessKey === "") {
+		alert('AccessKeyId and SecretAccessKey are required');
+	}
+
+	// update config data
+	AWS_AccessKeyId = AccessKeyId;
+	AWS_SecretAccessKey = SecretAccessKey;
+
+	$('#loginForm').remove();
+
+	$('#overlay').show();
+	runS3Browser()
+}
+
+$(document).ready(function() {
+	init();
+
+	// if keys are not available from config then ask user to provide those
+	if (!AWS_SecretAccessKey) {
+		showLoginForm();
+	} else {
+		runS3Browser();
+	}
 });


### PR DESCRIPTION
It is not safe to expose `js/config.js` with all the AWS creds, so 
an alternative option is added so that user will be prompted for AWS credentials if they are not available in `config.js`.

This change should not affect the default behavior when credentials are available.