### PR TITLE
Update AWS JS SDK to version 2.223.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 		<title>AWS S3 Bucket Browser .:Based on AWS SDK for JavaScript:.</title>
 		<link rel="stylesheet" type="text/css" href="css/theme.css">
 		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-		<script type="text/javascript" src="https://sdk.amazonaws.com/js/aws-sdk-2.0.0-rc1.min.js"></script>
+		<script src="https://sdk.amazonaws.com/js/aws-sdk-2.223.1.min.js"></script>
 	</head>
 	<body>
 		<script src="js/config.js"></script>	


### PR DESCRIPTION
Hi!

Thank you for the great S3 bucket browser!

I wanted to set up an instance of `s3-bucket-browser`, and I quickly stumbled upon the same problem as described in the issue #3: `Error: Could not load objects from S3`. There might be multiple reasons for this error message, but mine was at least caused by the lack of v4 signature in the request.

The thing is that [newer S3 regions do not support v2 signing anymore](https://docs.aws.amazon.com/general/latest/gr/signature-version-2.html). Older ones keep on working, why debugging this problem may be cumbersome. Luckily [the AWS JS SDK has switched to using v4 by default already in the version 2.68.0](https://github.com/aws/aws-sdk-js/blob/master/CHANGELOG.md#2680). AWS recommends v4 nowadays, and it should work in all current S3 regions.

This PR upgrades the JS SDK from version `2.0.0-rc1` to version `2.223.1` and thus most probably fixes #3. I at least haven't encountered any breaking changes which would prevent the browser working otherwise as intended.